### PR TITLE
1.x.x+neoforge/feat/playerMoneyVisualization

### DIFF
--- a/src/main/java/fr/valorantage/valomoney/ValomoneyMod.java
+++ b/src/main/java/fr/valorantage/valomoney/ValomoneyMod.java
@@ -3,6 +3,7 @@ package fr.valorantage.valomoney;
 import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
 import fr.valorantage.valomoney.block.ModBlocks;
 import fr.valorantage.valomoney.block.entity.ModBlockEntities;
+import fr.valorantage.valomoney.component.ModDataComponentTypes;
 import fr.valorantage.valomoney.item.ModCreativeModeTabs;
 import fr.valorantage.valomoney.item.ModItems;
 import fr.valorantage.valomoney.gui.ModMenuTypes;
@@ -55,6 +56,8 @@ public class ValomoneyMod {
         ModMenuTypes.register(modEventBus);
         // Register the Deferred Register to the mod event bus so attachments get registered
         ModAttachmentTypes.register(modEventBus);
+        // Register the Deferred Register to the mod event bus so data components get registered
+        ModDataComponentTypes.register(modEventBus);
 
         // Register ourselves for server and other game events we are interested in.
         // Note that this is necessary if and only if we want *this* class (ValomoneyMod) to respond directly to events.

--- a/src/main/java/fr/valorantage/valomoney/component/ModDataComponentTypes.java
+++ b/src/main/java/fr/valorantage/valomoney/component/ModDataComponentTypes.java
@@ -1,0 +1,26 @@
+package fr.valorantage.valomoney.component;
+
+import com.mojang.serialization.Codec;
+import fr.valorantage.valomoney.ValomoneyMod;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.Registries;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.UUID;
+import java.util.function.UnaryOperator;
+
+public class ModDataComponentTypes {
+    public static final DeferredRegister<DataComponentType<?>> DATA_COMPONENT_TYPES = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, ValomoneyMod.MODID);
+
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<String>> PLAYER_UUID = registerDataComponent("player_uuid", builder -> builder.persistent(Codec.STRING));
+
+    private static <T> DeferredHolder<DataComponentType<?>, DataComponentType<T>> registerDataComponent(String name, UnaryOperator<DataComponentType.Builder<T>> builderOperator) {
+        return DATA_COMPONENT_TYPES.register(name, () -> builderOperator.apply(DataComponentType.builder()).build());
+    }
+
+    public static void register(IEventBus bus) {
+        DATA_COMPONENT_TYPES.register(bus);
+    }
+}

--- a/src/main/java/fr/valorantage/valomoney/item/ModItems.java
+++ b/src/main/java/fr/valorantage/valomoney/item/ModItems.java
@@ -2,6 +2,7 @@ package fr.valorantage.valomoney.item;
 
 import fr.valorantage.valomoney.ValomoneyMod;
 import fr.valorantage.valomoney.block.ModBlocks;
+import fr.valorantage.valomoney.item.custom.BankCardItem;
 import fr.valorantage.valomoney.item.custom.MonetaryItem;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -21,7 +22,7 @@ public class ModItems {
     public static final DeferredItem<BlockItem> ATM_ITEM = ITEMS.register("atm", () -> new BlockItem(ModBlocks.ATM.get(), new Item.Properties()));
 
     // Creates bank card item
-    public static final DeferredItem<Item> BANK_CARD = ITEMS.registerSimpleItem("bank_card");
+    public static final DeferredItem<Item> BANK_CARD = ITEMS.register("bank_card", BankCardItem::new);
 
     public static void register(IEventBus eventBus) {
         ITEMS.register(eventBus);

--- a/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
@@ -1,8 +1,8 @@
 package fr.valorantage.valomoney.item.custom;
 
 import com.mojang.logging.LogUtils;
-import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
-import net.minecraft.nbt.CompoundTag;
+import fr.valorantage.valomoney.component.ModDataComponentTypes;
+import fr.valorantage.valomoney.network.packet.PlayerMoneyPayload;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -11,29 +11,37 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
-import net.neoforged.neoforge.items.ItemStackHandler;
+import net.neoforged.neoforge.network.PacketDistributor;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.UUID;
 
 public class BankCardItem extends Item {
     private final static Logger LOGGER = LogUtils.getLogger();
 
-    private Player player;
+    public static float PLAYER_MONEY = 0.f;
 
     public BankCardItem() {
         super(new Item.Properties());
 
-        this.player = null;
     }
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
         if (!level.isClientSide()) {
             LOGGER.debug("{} used bank card", player.getDisplayName().getString());
-            if (this.player == null) {
-                this.player = player;
-                LOGGER.debug("Bound bank card to player '{}'", this.player.getDisplayName().getString());
+
+            // FIXME: Refactor the way to read/write player UUID from data component
+            var stack = player.getItemInHand(usedHand);
+            String storedPlayerUUID = stack.get(ModDataComponentTypes.PLAYER_UUID);
+            if (storedPlayerUUID == null) {
+                player.getItemInHand(usedHand).set(ModDataComponentTypes.PLAYER_UUID, player.getStringUUID());
+                LOGGER.debug("Bound bank card to player '{}'", player.getDisplayName().getString());
+            } else {
+                // FIXME: Must check if storedPlayer is null
+                var storedPlayer = level.getPlayerByUUID(UUID.fromString(storedPlayerUUID));
+                LOGGER.debug("This bank card has already been bind to player '{}'", storedPlayer.getDisplayName().getString());
             }
         }
 
@@ -42,11 +50,18 @@ public class BankCardItem extends Item {
 
     @Override
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
-        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
+        // FIXME: Refactor the way to read/write player UUID from data component
+        String storedPlayerUUID = stack.get(ModDataComponentTypes.PLAYER_UUID);
+        if (storedPlayerUUID != null) {
+            var storedPlayer = context.level().getPlayerByUUID(UUID.fromString(storedPlayerUUID));
+            if (storedPlayer != null) {
+                // TODO: Optimize the number of packets send to the server (one packet sent by frame rendered)
+                PacketDistributor.sendToServer(new PlayerMoneyPayload(0));
 
-        if (this.player != null) {
-            float playerMoney = player.getData(ModAttachmentTypes.MONEY);
-            tooltipComponents.add(Component.literal(String.format("Money: %.2f$", playerMoney)));
+                tooltipComponents.add(Component.literal(String.format("Money: %.2f$", PLAYER_MONEY)));
+            }
         }
+
+        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
@@ -1,11 +1,48 @@
 package fr.valorantage.valomoney.item.custom;
 
+import com.mojang.logging.LogUtils;
+import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import org.slf4j.Logger;
+
+import java.util.List;
 
 public class BankCardItem extends Item {
+    private final static Logger LOGGER = LogUtils.getLogger();
+
+    private Player player;
+
     public BankCardItem() {
         super(new Item.Properties());
+
+        this.player = null;
     }
 
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
+        if (!level.isClientSide()) {
+            this.player = player;
+            LOGGER.debug("{} used bank card", this.player.getDisplayName().getString());
+        }
+        return super.use(level, player, usedHand);
+    }
 
+    @Override
+    public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
+        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
+
+        if (this.player != null) {
+            float playerMoney = player.getData(ModAttachmentTypes.MONEY);
+            tooltipComponents.add(Component.literal(String.format("Money: %.2f$", playerMoney)));
+        }
+    }
 }

--- a/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
@@ -56,6 +56,7 @@ public class BankCardItem extends Item {
             var storedPlayer = context.level().getPlayerByUUID(UUID.fromString(storedPlayerUUID));
             if (storedPlayer != null) {
                 // TODO: Optimize the number of packets send to the server (one packet sent by frame rendered)
+                // FIXME: storedPlayer is not used, so any player will see it's balance, so the data component is useless
                 PacketDistributor.sendToServer(new PlayerMoneyPayload(0));
 
                 tooltipComponents.add(Component.literal(String.format("Money: %.2f$", PLAYER_MONEY)));

--- a/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
@@ -2,16 +2,16 @@ package fr.valorantage.valomoney.item.custom;
 
 import com.mojang.logging.LogUtils;
 import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.items.ItemStackHandler;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -30,9 +30,13 @@ public class BankCardItem extends Item {
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
         if (!level.isClientSide()) {
-            this.player = player;
-            LOGGER.debug("{} used bank card", this.player.getDisplayName().getString());
+            LOGGER.debug("{} used bank card", player.getDisplayName().getString());
+            if (this.player == null) {
+                this.player = player;
+                LOGGER.debug("Bound bank card to player '{}'", this.player.getDisplayName().getString());
+            }
         }
+
         return super.use(level, player, usedHand);
     }
 

--- a/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/BankCardItem.java
@@ -1,0 +1,11 @@
+package fr.valorantage.valomoney.item.custom;
+
+import net.minecraft.world.item.Item;
+
+public class BankCardItem extends Item {
+    public BankCardItem() {
+        super(new Item.Properties());
+    }
+
+
+}

--- a/src/main/java/fr/valorantage/valomoney/network/ClientPayloadHandler.java
+++ b/src/main/java/fr/valorantage/valomoney/network/ClientPayloadHandler.java
@@ -1,7 +1,9 @@
 package fr.valorantage.valomoney.network;
 
 import com.mojang.logging.LogUtils;
+import fr.valorantage.valomoney.item.custom.BankCardItem;
 import fr.valorantage.valomoney.network.packet.ATMDebitPayload;
+import fr.valorantage.valomoney.network.packet.PlayerMoneyPayload;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import org.slf4j.Logger;
 
@@ -11,5 +13,12 @@ public class ClientPayloadHandler {
     public static void handleATMDebitPayloadOnNetwork(final ATMDebitPayload data, final IPayloadContext context) {
         // Do something with the data, on the network thread
         LOGGER.debug("Client received ATMDebitPayload: {}", data);
+    }
+
+    public static void handlePlayerMoneyPayloadOnNetwork(final PlayerMoneyPayload data, final IPayloadContext context) {
+        // Do something with the data, on the network thread
+        LOGGER.debug("Client received PlayerMoneyPayload: {}", data);
+
+        BankCardItem.PLAYER_MONEY = data.amount();
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/network/ModPayloads.java
+++ b/src/main/java/fr/valorantage/valomoney/network/ModPayloads.java
@@ -3,9 +3,11 @@ package fr.valorantage.valomoney.network;
 import fr.valorantage.valomoney.ValomoneyMod;
 import fr.valorantage.valomoney.network.packet.ATMCreditPayload;
 import fr.valorantage.valomoney.network.packet.ATMDebitPayload;
+import fr.valorantage.valomoney.network.packet.PlayerMoneyPayload;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.handling.DirectionalPayloadHandler;
 import net.neoforged.neoforge.network.registration.HandlerThread;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
@@ -17,18 +19,29 @@ public class ModPayloads {
         final PayloadRegistrar registrar = event.registrar("1")
                 .executesOn(HandlerThread.NETWORK);
 
-        // Register ATMDebitPayload (Only Client -> Server)
+        // TODO: Create a method to refactor those instructions
+        // Register ATMDebitPayload (Client -> Server)
         registrar.playToServer(
                 ATMDebitPayload.TYPE,
                 ATMDebitPayload.STREAM_CODEC,
                 ServerPayloadHandler::handleATMDebitPayloadOnNetwork
         );
 
-        // Register ATMCreditPayload (Only Client -> Server)
+        // Register ATMCreditPayload (Client -> Server)
         registrar.playToServer(
                 ATMCreditPayload.TYPE,
                 ATMCreditPayload.STREAM_CODEC,
                 ServerPayloadHandler::handleATMCreditPayloadOnNetwork
+        );
+
+        // Register PlayerMoneyPayload (Server <-> Client)
+        registrar.playBidirectional(
+                PlayerMoneyPayload.TYPE,
+                PlayerMoneyPayload.STREAM_CODEC,
+                new DirectionalPayloadHandler<>(
+                        ClientPayloadHandler::handlePlayerMoneyPayloadOnNetwork,
+                        ServerPayloadHandler::handlePlayerMoneyPayloadOnNetwork
+                )
         );
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/network/ServerPayloadHandler.java
+++ b/src/main/java/fr/valorantage/valomoney/network/ServerPayloadHandler.java
@@ -1,9 +1,11 @@
 package fr.valorantage.valomoney.network;
 
 import com.mojang.logging.LogUtils;
+import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
 import fr.valorantage.valomoney.gui.custom.ATMMenu;
 import fr.valorantage.valomoney.network.packet.ATMCreditPayload;
 import fr.valorantage.valomoney.network.packet.ATMDebitPayload;
+import fr.valorantage.valomoney.network.packet.PlayerMoneyPayload;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import org.slf4j.Logger;
@@ -27,5 +29,14 @@ public class ServerPayloadHandler {
         ServerPlayer player = (ServerPlayer) context.player();
         ATMMenu atmMenu = (ATMMenu) player.containerMenu;
         atmMenu.credit(data.amount());
+    }
+
+    public static void handlePlayerMoneyPayloadOnNetwork(final PlayerMoneyPayload data, final IPayloadContext context) {
+        // Do something with the data, on the network thread
+        LOGGER.debug("Server received PlayerMoneyPayload: {}", data);
+
+        ServerPlayer player = (ServerPlayer) context.player();
+        float playerMoney = player.getData(ModAttachmentTypes.MONEY);
+        context.reply(new PlayerMoneyPayload(playerMoney));
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/network/packet/ATMCreditPayload.java
+++ b/src/main/java/fr/valorantage/valomoney/network/packet/ATMCreditPayload.java
@@ -7,6 +7,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
 public record ATMCreditPayload(float amount) implements CustomPacketPayload {
+    // FIXME: Replace 'valomoney' by ValomoneyMod.MODID
     public static final CustomPacketPayload.Type<ATMCreditPayload> TYPE =
             new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath("valomoney", "atm_credit_payload"));
 

--- a/src/main/java/fr/valorantage/valomoney/network/packet/PlayerMoneyPayload.java
+++ b/src/main/java/fr/valorantage/valomoney/network/packet/PlayerMoneyPayload.java
@@ -1,23 +1,24 @@
 package fr.valorantage.valomoney.network.packet;
 
+import fr.valorantage.valomoney.ValomoneyMod;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
-public record ATMDebitPayload(float amount) implements CustomPacketPayload {
-    // FIXME: Replace 'valomoney' by ValomoneyMod.MODID
-    public static final CustomPacketPayload.Type<ATMDebitPayload> TYPE =
-            new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath("valomoney", "atm_debit_payload"));
+import java.util.UUID;
+
+public record PlayerMoneyPayload(float amount) implements CustomPacketPayload {
+    public static final CustomPacketPayload.Type<PlayerMoneyPayload> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(ValomoneyMod.MODID, "player_money_payload"));
 
     // Each pair of elements defines the stream codec of the element to encode/decode and the getter for the element to encode
     // 'amount' will be encoded and decoded as a float
     // The final parameter takes in the previous parameters in the order they are provided to construct the payload object
-    public static final StreamCodec<ByteBuf, ATMDebitPayload> STREAM_CODEC = StreamCodec.composite(
+    public static final StreamCodec<ByteBuf, PlayerMoneyPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.FLOAT,
-            ATMDebitPayload::amount,
-            ATMDebitPayload::new
+            PlayerMoneyPayload::amount,
+            PlayerMoneyPayload::new
     );
 
     @Override


### PR DESCRIPTION
### Items
- Introduced a custom BankCardItem class and applied it to the registered BANK_CARD item.
- Players can bind themselves to a bank card by right-clicking it.

### Data & Networking
- Added a PLAYER_UUID component to store a player's UUID (String) within the bank card's ItemStack.
- This UUID is used to query the server for the corresponding player’s balance and display it in the card’s tooltip.
- Implemented a bidirectional PlayerMoneyPayload to allow the client to request the player’s balance from the server.

> [!CAUTION]
>  ### Known bugs
> - The UUID bound to the bank card is currently unused, meaning any player sees their own balance regardless of the card. The stored data component is effectively ignored.
> - The client is sending payloads to the server every frame to request the balance, which results in excessive network traffic.