### PR TITLE
1.x.x+neoforge/fix/atmMultipleFunctionalIssues

### DIFF
--- a/src/main/java/fr/valorantage/valomoney/block/custom/ATMBlock.java
+++ b/src/main/java/fr/valorantage/valomoney/block/custom/ATMBlock.java
@@ -69,6 +69,4 @@ public class ATMBlock extends BaseEntityBlock {
         }
         return ItemInteractionResult.SUCCESS;
     }
-
-    // FIXME: Override useWithoutItem method
 }

--- a/src/main/java/fr/valorantage/valomoney/block/custom/ATMBlock.java
+++ b/src/main/java/fr/valorantage/valomoney/block/custom/ATMBlock.java
@@ -52,6 +52,12 @@ public class ATMBlock extends BaseEntityBlock {
 
     @Override
     protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+        if (state.getBlock() != newState.getBlock()) {
+            if (level.getBlockEntity(pos) instanceof ATMBlockEntity atmBlockEntity) {
+                atmBlockEntity.drops();
+            }
+        }
+
         super.onRemove(state, level, pos, newState, movedByPiston);
     }
 

--- a/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
+++ b/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
@@ -18,18 +18,25 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ATMBlockEntity extends BlockEntity implements MenuProvider {
     public final ItemStackHandler inventory = new ItemStackHandler(1) {
         @Override
         public boolean isItemValid(int slot, ItemStack stack) {
-            return stack.getItem() == ModItems.BANK_CARD.get() && slot == 0;
+            return stack.is(ModItems.BANK_CARD.get()) && slot == 0;
         }
 
         @Override
-        protected int getStackLimit(int slot, ItemStack stack) {
+        protected int getStackLimit(int slot, @NotNull ItemStack stack) {
             return 1;
+        }
+
+        @Override
+        public @NotNull ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
+            // TODO: Must reimplement this method to insert only one bank card (must be bound)
+            return ItemStack.EMPTY;
         }
 
         @Override

--- a/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
+++ b/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
@@ -18,25 +18,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.items.ItemStackHandler;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ATMBlockEntity extends BlockEntity implements MenuProvider {
     public final ItemStackHandler inventory = new ItemStackHandler(1) {
         @Override
         public boolean isItemValid(int slot, ItemStack stack) {
-            return stack.is(ModItems.BANK_CARD.get()) && slot == 0;
+            return stack.getItem() == ModItems.BANK_CARD.get() && slot == 0;
         }
 
         @Override
-        protected int getStackLimit(int slot, @NotNull ItemStack stack) {
+        protected int getStackLimit(int slot, ItemStack stack) {
             return 1;
-        }
-
-        @Override
-        public @NotNull ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-            // TODO: Must reimplement this method to insert only one bank card (must be bound)
-            return ItemStack.EMPTY;
         }
 
         @Override

--- a/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
+++ b/src/main/java/fr/valorantage/valomoney/block/entity/custom/ATMBlockEntity.java
@@ -10,7 +10,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.Containers;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -45,6 +47,14 @@ public class ATMBlockEntity extends BlockEntity implements MenuProvider {
         super(ModBlockEntities.ATM_BE.get(), pos, blockState);
     }
 
+    public void drops() {
+        SimpleContainer container = new SimpleContainer(this.inventory.getSlots());
+        for (int i = 0; i < container.getContainerSize(); i++) {
+            container.setItem(i, this.inventory.getStackInSlot(i));
+        }
+        Containers.dropContents(this.level, this.worldPosition, container);
+    }
+
     @Override
     public Component getDisplayName() {
         return Component.literal("ATM");
@@ -76,5 +86,4 @@ public class ATMBlockEntity extends BlockEntity implements MenuProvider {
         super.loadAdditional(tag, registries);
         inventory.deserializeNBT(registries, tag.getCompound("inventory"));
     }
-
 }

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -121,13 +121,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getVanillaInventorySlot(0).set(createBoundBankCard(fakePlayer));
+        atmMenu.getVanillaInventorySlot(0).set(createBoundBankCard(fakePlayer, 64));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
-                bankCardSlot, new ItemStack(ModItems.BANK_CARD.get(), 63),
-                atmMenu.getTileInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get())
+                bankCardSlot, ItemStack.EMPTY,
+                atmMenu.getTileInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get(), 64)
         ));
     }
 
@@ -183,7 +183,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
+        atmMenu.getVanillaInventorySlot(0).set(createBoundBankCard(fakePlayer, 63));
 
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 atmMenu.getTileInventorySlot(0).index, ItemStack.EMPTY,
@@ -261,11 +261,9 @@ public class ATMGameTests {
         helper.getLevel().destroyBlock(atmPos, true);
 
         // Check for drops (Expected ATM block item and one bank card)
-        helper.runAfterDelay(2, () -> {
-            helper.succeedIf(() -> GameTestUtils.assertDrops(helper, new AABB(atmPos), List.of(
-                    new ItemStack(ModBlocks.ATM.asItem()))
-            ));
-        });
+        helper.runAfterDelay(2, () -> helper.succeedIf(() -> GameTestUtils.assertDrops(helper, new AABB(atmPos), List.of(
+                new ItemStack(ModBlocks.ATM.asItem()))
+        )));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -274,18 +272,16 @@ public class ATMGameTests {
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
 
         // Place ATM block without a bank card
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Break ATM block
         helper.getLevel().destroyBlock(atmPos, true);
 
         // Check for drops (Expected ATM block item and one bank card)
-        helper.runAfterDelay(2, () -> {
-            helper.succeedIf(() -> GameTestUtils.assertDrops(helper, new AABB(atmPos), List.of(
-                    new ItemStack(ModItems.BANK_CARD.get()),
-                    new ItemStack(ModBlocks.ATM.asItem()))
-            ));
-        });
+        helper.runAfterDelay(2, () -> helper.succeedIf(() -> GameTestUtils.assertDrops(helper, new AABB(atmPos), List.of(
+                new ItemStack(ModItems.BANK_CARD.get()),
+                new ItemStack(ModBlocks.ATM.asItem()))
+        )));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -366,7 +362,7 @@ public class ATMGameTests {
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyBills(GameTestHelper helper) {
         // Create a fake player and move it inside the gametest structure, and assign it an initial balance
-        final float initialBalance = 0.f;
+        final float initialBalance = 10.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Place ATM block with a bank card
@@ -391,7 +387,7 @@ public class ATMGameTests {
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyBillsMultipleStacks(GameTestHelper helper) {
         // Create a fake player and move it inside the gametest structure, and assign it an initial balance
-        final float initialBalance = 0.f;
+        final float initialBalance = 640.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Place ATM block with a bank card
@@ -417,7 +413,7 @@ public class ATMGameTests {
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyCoins(GameTestHelper helper) {
         // Create a fake player and move it inside the gametest structure, and assign it an initial balance
-        final float initialBalance = 0.f;
+        final float initialBalance = 2.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Place ATM block with a bank card
@@ -442,7 +438,7 @@ public class ATMGameTests {
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitBillsAndCoins(GameTestHelper helper) {
         // Create a fake player and move it inside the gametest structure, and assign it an initial balance
-        final float initialBalance = 0.f;
+        final float initialBalance = 12.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Place ATM block with a bank card

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -99,13 +99,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, ItemStack.EMPTY,
-                atmMenu.getTileInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -120,13 +120,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 64));
+        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get(), 64));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, new ItemStack(ModItems.BANK_CARD.get(), 63),
-                atmMenu.getTileInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -141,13 +141,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(Blocks.STONE));
+        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(Blocks.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
         final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 stoneSlot, new ItemStack(Blocks.STONE),
-                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY
+                atmMenu.getTileInventorySlot(0).index, ItemStack.EMPTY
         ));
     }
 
@@ -163,8 +163,8 @@ public class ATMGameTests {
 
         // Move the bank card from ATM's inventory to the fake player's inventory using 'quickMoveStack' method
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
-                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
-                atmMenu.getVanillaInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventorySlot(0).index, ItemStack.EMPTY,
+                atmMenu.getVanillaInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -179,11 +179,11 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
+        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
-                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
-                atmMenu.getVanillaInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get(), 64)
+                atmMenu.getTileInventorySlot(0).index, ItemStack.EMPTY,
+                atmMenu.getVanillaInventorySlot(0).index, new ItemStack(ModItems.BANK_CARD.get(), 64)
         ));
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -60,7 +60,7 @@ public class ATMGameTests {
     }
 
     @GameTest(template = BASICS_TEMPLATE)
-    public static void useWithItem(GameTestHelper helper) {
+    public static void useItemOn(GameTestHelper helper) {
         // Place ATM block and check for block type and block entity type
         BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
 
@@ -72,20 +72,6 @@ public class ATMGameTests {
                 Vec3.atCenterOf(atmPos), Direction.NORTH, atmPos, false));
 
         helper.succeedIf(() -> helper.assertValueEqual(interactionResult, ItemInteractionResult.SUCCESS, "atmItemInteractionResult"));
-    }
-
-    @GameTest(template = BASICS_TEMPLATE)
-    public static void useWithoutItem(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player, teleport it to structure and make it use ATM to open the GUI
-        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
-        BlockState state = helper.getLevel().getBlockState(atmPos);
-        InteractionResult interactionResult = state.useWithoutItem(helper.getLevel(), fakePlayer, new BlockHitResult(
-                Vec3.atCenterOf(atmPos), Direction.NORTH, atmPos, false));
-
-        helper.succeedIf(() -> helper.assertValueEqual(interactionResult, InteractionResult.SUCCESS, "atmInteractionResult"));
     }
 
     @GameTest(template = BASICS_TEMPLATE)

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -100,7 +100,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -121,7 +121,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -142,7 +142,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(Blocks.STONE));
+        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(Blocks.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
         final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
@@ -180,7 +180,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
+        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -13,7 +13,6 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -24,7 +23,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.gametest.GameTestHolder;
-import net.neoforged.neoforge.items.SlotItemHandler;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -60,24 +58,6 @@ public class ATMGameTests {
             helper.fail("Could not open ATM menu", atmPos);
             return null;
         }
-    }
-
-    private static int searchItemInMenu(ATMMenu atmMenu, Item item) {
-        return atmMenu.slots.stream()
-                .filter(slot -> slot.getItem().is(item))
-                .findFirst()
-                .map(slot -> slot.index)
-                .orElse(-1);
-    }
-
-    private static void assertQuickMoveStack(GameTestHelper helper, Player player, ATMMenu atmMenu, int srcIndex, ItemStack expectedSrcItemStack, int dstIndex, ItemStack expectedDstItemStack) {
-        atmMenu.quickMoveStack(player, srcIndex);
-
-        var actualSrcSlotItemStack = atmMenu.slots.get(srcIndex).getItem();
-        helper.assertValueEqual(actualSrcSlotItemStack.toString(), expectedSrcItemStack.toString(), "menuSrcSlotItemStack");
-
-        var actualDstSlotItemStack = atmMenu.slots.get(dstIndex).getItem();
-        helper.assertValueEqual(actualDstSlotItemStack.getItem(), expectedDstItemStack.getItem(), "menuDstSlotItemStack");
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -123,8 +103,8 @@ public class ATMGameTests {
         atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
-        final int bankCardSlot = searchItemInMenu(atmMenu, ModItems.BANK_CARD.get());
-        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+        final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
+        helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, ItemStack.EMPTY,
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
         ));
@@ -144,8 +124,8 @@ public class ATMGameTests {
         atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
-        final int bankCardSlot = searchItemInMenu(atmMenu, ModItems.BANK_CARD.get());
-        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+        final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
+        helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, new ItemStack(ModItems.BANK_CARD.get(), 63),
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
         ));
@@ -165,8 +145,8 @@ public class ATMGameTests {
         atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(Blocks.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
-        final int stoneSlot = searchItemInMenu(atmMenu, Items.STONE);
-        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+        final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
+        helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 stoneSlot, new ItemStack(Blocks.STONE),
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY
         ));
@@ -183,7 +163,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Move the bank card from ATM's inventory to the fake player's inventory using 'quickMoveStack' method
-        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+        helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
                 ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
         ));
@@ -202,7 +182,7 @@ public class ATMGameTests {
         // Add bank card in fake player's inventory
         atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
-        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+        helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
                 ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get(), 64)
         ));

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -99,7 +99,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -120,7 +120,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -141,7 +141,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(Blocks.STONE));
+        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(Blocks.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
         final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
@@ -164,7 +164,7 @@ public class ATMGameTests {
         // Move the bank card from ATM's inventory to the fake player's inventory using 'quickMoveStack' method
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
-                atmMenu.getVanillaFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getVanillaInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -179,11 +179,11 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
+        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
-                atmMenu.getVanillaFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get(), 64)
+                atmMenu.getVanillaInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get(), 64)
         ));
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -377,6 +377,32 @@ public class ATMGameTests {
     }
 
     @GameTest(template = BASICS_TEMPLATE)
+    public static void debitOnlyBillsMultipleStacks(GameTestHelper helper) {
+        // Place ATM block and check for block type and block entity type
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
+
+        // Create a fake player
+        final float initialBalance = 640.f;
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Open ATM menu for fake player
+        ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
+
+        helper.succeedIf(() -> {
+            // Set amount to debit
+            final float amount = 640.f;
+
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
+            atmMenu.debit(amount);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance - amount);
+            GameTestUtils.assertInventoryEquals(helper, fakePlayer.getInventory(), List.of(
+                    new ItemStack(ModItems.BILL.get(), 64),
+                    new ItemStack(ModItems.BILL.get(), 64)
+            ));
+        });
+    }
+
+    @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyCoins(GameTestHelper helper) {
         // Place ATM block and check for block type and block entity type
         BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -120,7 +120,7 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(atmMenu.getVanillaInventoryFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 64));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -193,7 +193,8 @@ public class ATMGameTests {
         BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
 
         // Create a fake player
-        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+        final float initialBalance = 0.f;
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Add cash items in fake player's inventory (10x1+5x5=35$) and a bank card
         fakePlayer.getInventory().add(new ItemStack(ModItems.COIN.get(), 10));
@@ -207,11 +208,11 @@ public class ATMGameTests {
             // Set amount to credit and debit
             final float amount = 35.f;
 
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, 0.f);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
             atmMenu.credit(amount);
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, amount);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance + amount);
             atmMenu.debit(amount);
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, 0.f);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
         });
     }
 
@@ -221,7 +222,8 @@ public class ATMGameTests {
         BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
 
         // Create a fake player
-        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+        final float initialBalance = 0.f;
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
         // Add cash items in fake player's inventory (10x1+5x5=35$)
         fakePlayer.getInventory().add(new ItemStack(ModItems.COIN.get(), 10));
@@ -235,11 +237,11 @@ public class ATMGameTests {
             // Set amount to credit and debit
             final float amount = 35.f;
 
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, 0.f);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
             atmMenu.credit(amount);
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, 0.f);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
             atmMenu.debit(amount);
-            GameTestUtils.assertPlayersMoney(helper, fakePlayer, 0.f);
+            GameTestUtils.assertPlayersMoney(helper, fakePlayer, initialBalance);
         });
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -4,6 +4,7 @@ import com.mojang.logging.LogUtils;
 import fr.valorantage.valomoney.ValomoneyMod;
 import fr.valorantage.valomoney.block.ModBlocks;
 import fr.valorantage.valomoney.block.entity.custom.ATMBlockEntity;
+import fr.valorantage.valomoney.component.ModDataComponentTypes;
 import fr.valorantage.valomoney.gui.custom.ATMMenu;
 import fr.valorantage.valomoney.item.ModItems;
 import net.minecraft.core.BlockPos;
@@ -32,7 +33,17 @@ public class ATMGameTests {
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final String BASICS_TEMPLATE = "basics";
 
-    private static BlockPos placeATMAndCheck(GameTestHelper helper, BlockPos relativePos, boolean withBankCard) {
+    private static ItemStack createBoundBankCard(Player player, int count) {
+        var bankCard = new ItemStack(ModItems.BANK_CARD.get(), count);
+        bankCard.set(ModDataComponentTypes.PLAYER_UUID.get(), player.getUUID().toString());
+        return bankCard;
+    }
+
+    private static ItemStack createBoundBankCard(Player player) {
+        return createBoundBankCard(player, 1);
+    }
+
+    private static BlockPos placeATMAndCheck(GameTestHelper helper, BlockPos relativePos, Player player, boolean withBankCard) {
         BlockPos pos = GameTestUtils.placeBlock(helper, relativePos, ModBlocks.ATM.get());
 
         // Check block & block entity
@@ -41,7 +52,7 @@ public class ATMGameTests {
 
         if (withBankCard) {
             ATMBlockEntity atmBlockEntity = (ATMBlockEntity) helper.getLevel().getBlockEntity(pos);
-            atmBlockEntity.inventory.insertItem(0, new ItemStack(ModItems.BANK_CARD.get()), false);
+            atmBlockEntity.inventory.insertItem(0, createBoundBankCard(player), false);
         }
 
         return pos;
@@ -61,11 +72,13 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void useItemOn(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player, teleport it to structure and make it use ATM to open the GUI
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
+
+        // Make fake player use the ATM to open the GUI
         BlockState state = helper.getLevel().getBlockState(atmPos);
         var usedItemStack = new ItemStack(Blocks.STONE, 64);
         ItemInteractionResult interactionResult = state.useItemOn(usedItemStack, helper.getLevel(), fakePlayer, InteractionHand.MAIN_HAND, new BlockHitResult(
@@ -76,16 +89,17 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void quickMoveBankCard(GameTestHelper helper) {
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getVanillaInventorySlot(0).set(createBoundBankCard(fakePlayer));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -97,16 +111,17 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void quickMoveBankCardStack(GameTestHelper helper) {
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(ModItems.BANK_CARD.get(), 64));
+        atmMenu.getVanillaInventorySlot(0).set(createBoundBankCard(fakePlayer));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
@@ -118,16 +133,17 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void quickMoveOtherItem(GameTestHelper helper) {
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
-        // Add bank card in fake player's inventory
-        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(Blocks.STONE));
+        // Add stone blocks in fake player's inventory
+        atmMenu.getVanillaInventorySlot(0).set(new ItemStack(Items.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
         final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
@@ -139,10 +155,11 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void quickMoveBankCardInInventory(GameTestHelper helper) {
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -156,10 +173,11 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void quickMoveBankCardInInventoryExistingStack(GameTestHelper helper) {
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -175,12 +193,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void basicTransaction(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Add cash items in fake player's inventory (10x1+5x5=35$) and a bank card
         fakePlayer.getInventory().add(new ItemStack(ModItems.COIN.get(), 10));
@@ -204,12 +222,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void basicTransactionWithoutBankCard(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Add cash items in fake player's inventory (10x1+5x5=35$)
         fakePlayer.getInventory().add(new ItemStack(ModItems.COIN.get(), 10));
@@ -233,8 +251,11 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void dropsOnRemoveEmpty(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), false);
+        // Create a fake player and move it inside the gametest structure
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Break ATM block
         helper.getLevel().destroyBlock(atmPos, true);
@@ -249,8 +270,11 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void dropsOnRemove(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
+        // Create a fake player and move it inside the gametest structure
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
+
+        // Place ATM block without a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, false);
 
         // Break ATM block
         helper.getLevel().destroyBlock(atmPos, true);
@@ -266,12 +290,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitInsufficientFunds(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -289,12 +313,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitInventoryFull(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
+        final float initialBalance = 0.f;
+        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
 
-        // Create a fake player
-        final float initialBalance = 100.f;
-        Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 100.f);
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Fill player's inventory with stone
         var playerInventory = fakePlayer.getInventory();
@@ -318,12 +342,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitInvalidAmount(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -341,12 +365,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyBills(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
-        final float initialBalance = 10.f;
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
+        final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -366,12 +390,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyBillsMultipleStacks(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
-        final float initialBalance = 640.f;
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
+        final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -392,12 +416,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitOnlyCoins(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
-        final float initialBalance = 10.f;
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
+        final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -417,12 +441,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void debitBillsAndCoins(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
-        final float initialBalance = 12.f;
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
+        final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -443,12 +467,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void creditNoCash(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
@@ -466,12 +490,12 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void creditNoCashButOtherItems(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
 
         // Fill player's inventory with stone
         var playerInventory = fakePlayer.getInventory();
@@ -495,12 +519,14 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void creditNotEnoughCash(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
+
+        //
         fakePlayer.getInventory().add(new ItemStack(ModItems.BILL.get(), 1));
         fakePlayer.getInventory().add(new ItemStack(ModItems.COIN.get(), 2));
 
@@ -520,12 +546,14 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void creditTooMuchCash(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
+
+        //
         fakePlayer.getInventory().add(new ItemStack(ModItems.BILL.get(), 10));
 
         // Open ATM menu for fake player
@@ -544,12 +572,14 @@ public class ATMGameTests {
 
     @GameTest(template = BASICS_TEMPLATE)
     public static void creditCashEqualToAmount(GameTestHelper helper) {
-        // Place ATM block and check for block type and block entity type
-        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), true);
-
-        // Create a fake player
+        // Create a fake player and move it inside the gametest structure, and assign it an initial balance
         final float initialBalance = 0.f;
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), initialBalance);
+
+        // Place ATM block with a bank card
+        BlockPos atmPos = placeATMAndCheck(helper, new BlockPos(0, 2, 0), fakePlayer, true);
+
+        //
         fakePlayer.getInventory().add(new ItemStack(ModItems.BILL.get(), 10));
 
         // Open ATM menu for fake player

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -13,7 +13,10 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -21,6 +24,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.items.SlotItemHandler;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -56,6 +60,24 @@ public class ATMGameTests {
             helper.fail("Could not open ATM menu", atmPos);
             return null;
         }
+    }
+
+    private static int searchItemInMenu(ATMMenu atmMenu, Item item) {
+        return atmMenu.slots.stream()
+                .filter(slot -> slot.getItem().is(item))
+                .findFirst()
+                .map(slot -> slot.index)
+                .orElse(-1);
+    }
+
+    private static void assertQuickMoveStack(GameTestHelper helper, Player player, ATMMenu atmMenu, int srcIndex, ItemStack expectedSrcItemStack, int dstIndex, ItemStack expectedDstItemStack) {
+        atmMenu.quickMoveStack(player, srcIndex);
+
+        var actualSrcSlotItemStack = atmMenu.slots.get(srcIndex).getItem();
+        helper.assertValueEqual(actualSrcSlotItemStack.toString(), expectedSrcItemStack.toString(), "menuSrcSlotItemStack");
+
+        var actualDstSlotItemStack = atmMenu.slots.get(dstIndex).getItem();
+        helper.assertValueEqual(actualDstSlotItemStack.getItem(), expectedDstItemStack.getItem(), "menuDstSlotItemStack");
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -94,27 +116,18 @@ public class ATMGameTests {
         // Create a fake player
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
 
-        // Add bank card in fake player's inventory
-        fakePlayer.getInventory().add(new ItemStack(ModItems.BANK_CARD.get()));
-
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
+        // Add bank card in fake player's inventory
+        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
-        int bankCardSlot = GameTestUtils.findItemSlotInInventory(fakePlayer.getInventory(), ModItems.BANK_CARD.get());
-
-        helper.succeedIf(() -> {
-            helper.assertTrue(bankCardSlot >= 0, "No bank card found in player's inventory");
-            atmMenu.quickMoveStack(fakePlayer, bankCardSlot);
-
-            var actualAtmSlotItemStack = atmMenu.slots.getFirst().getItem();
-            var expectedAtmSlotItemStack = new ItemStack(ModItems.BANK_CARD.get());
-            helper.assertValueEqual(actualAtmSlotItemStack, expectedAtmSlotItemStack, "atmSlotItemStack");
-
-            var actualBankCardSlotItemStack = fakePlayer.getInventory().getItem(bankCardSlot);
-            var expectedBankCardSlotItemStack = new ItemStack(ModItems.BANK_CARD.get(), 63);
-            helper.assertValueEqual(actualBankCardSlotItemStack, expectedBankCardSlotItemStack, "bankCardSlotItem");
-        });
+        final int bankCardSlot = searchItemInMenu(atmMenu, ModItems.BANK_CARD.get());
+        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+                bankCardSlot, ItemStack.EMPTY,
+                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+        ));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -124,26 +137,18 @@ public class ATMGameTests {
         // Create a fake player
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
 
-        // Add bank cards stack in fake player's inventory
-        fakePlayer.getInventory().add(new ItemStack(ModItems.BANK_CARD.get(), 64));
-
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
+
+        // Add bank card in fake player's inventory
+        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
-        int bankCardSlot = GameTestUtils.findItemSlotInInventory(fakePlayer.getInventory(), ModItems.BANK_CARD.get());
-
-        helper.succeedIf(() -> {
-            helper.assertTrue(bankCardSlot >= 0, "No bank card found in player's inventory");
-            atmMenu.quickMoveStack(fakePlayer, bankCardSlot);
-
-            var actualAtmSlotItemStack = atmMenu.slots.getFirst().getItem();
-            var expectedAtmSlotItemStack = new ItemStack(ModItems.BANK_CARD.get());
-            helper.assertValueEqual(actualAtmSlotItemStack, expectedAtmSlotItemStack, "atmSlotItemStack");
-
-            var actualBankCardSlotItemStack = fakePlayer.getInventory().getItem(bankCardSlot);
-            var expectedBankCardSlotItemStack = new ItemStack(ModItems.BANK_CARD.get(), 63);
-            helper.assertValueEqual(actualBankCardSlotItemStack, expectedBankCardSlotItemStack, "bankCardSlotItem");
-        });
+        final int bankCardSlot = searchItemInMenu(atmMenu, ModItems.BANK_CARD.get());
+        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+                bankCardSlot, new ItemStack(ModItems.BANK_CARD.get(), 63),
+                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+        ));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -153,26 +158,18 @@ public class ATMGameTests {
         // Create a fake player
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
 
-        // Add bank card in fake player's inventory
-        fakePlayer.getInventory().add(new ItemStack(Blocks.STONE));
-
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
+
+        // Add bank card in fake player's inventory
+        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(Blocks.STONE));
+
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
-        int stoneSlot = GameTestUtils.findItemSlotInInventory(fakePlayer.getInventory(), Blocks.STONE.asItem());
-
-        helper.succeedIf(() -> {
-            helper.assertTrue(stoneSlot >= 0, "No bank card found in player's inventory");
-
-            atmMenu.quickMoveStack(fakePlayer, stoneSlot);
-            var actualAtmSlotItemStack = atmMenu.slots.getFirst().getItem();
-            var expectedAtmSlotItemStack = new ItemStack(Blocks.STONE);
-            helper.assertValueEqual(actualAtmSlotItemStack, expectedAtmSlotItemStack, "atmSlotItemStack");
-
-            var actualStoneSlotItemStack = fakePlayer.getInventory().getItem(stoneSlot);
-            var expectedStoneSlotItemStack = new ItemStack(ModItems.BANK_CARD.get(), 63);
-            helper.assertValueEqual(actualStoneSlotItemStack, expectedStoneSlotItemStack, "bankCardSlotItem");
-        });
+        final int stoneSlot = searchItemInMenu(atmMenu, Items.STONE);
+        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+                stoneSlot, new ItemStack(Blocks.STONE),
+                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY
+        ));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -185,17 +182,11 @@ public class ATMGameTests {
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
-        helper.succeedIf(() -> {
-            atmMenu.quickMoveStack(fakePlayer, atmMenu.slots.getFirst().index);
-
-            var actualAtmSlotItemStack = atmMenu.slots.getFirst().getItem();
-            var expectedAtmSlotItemStack = ItemStack.EMPTY;
-            helper.assertValueEqual(actualAtmSlotItemStack, expectedAtmSlotItemStack, "atmSlotItemStack");
-
-            var actualInventoryFirstSlotItemStack = fakePlayer.getInventory().getItem(0);
-            var expectedInventoryFirstSlotItemStack = new ItemStack(ModItems.BANK_CARD.get());
-            helper.assertValueEqual(actualInventoryFirstSlotItemStack, expectedInventoryFirstSlotItemStack, "inventoryFirstSlotItemStack");
-        });
+        // Move the bank card from ATM's inventory to the fake player's inventory using 'quickMoveStack' method
+        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
+                ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+        ));
     }
 
     @GameTest(template = BASICS_TEMPLATE)
@@ -205,23 +196,16 @@ public class ATMGameTests {
         // Create a fake player
         Player fakePlayer = GameTestUtils.makeMockPlayer(helper, GameType.SURVIVAL, new BlockPos(1, 2, 0), 0.f);
 
-        // Add bank cards stack in fake player's inventory
-        fakePlayer.getInventory().add(new ItemStack(ModItems.BANK_CARD.get(), 63));
-
         // Open ATM menu for fake player
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
-        helper.succeedIf(() -> {
-            atmMenu.quickMoveStack(fakePlayer, atmMenu.slots.getFirst().index);
+        // Add bank card in fake player's inventory
+        atmMenu.slots.get(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
-            var actualAtmSlotItemStack = atmMenu.slots.getFirst().getItem();
-            var expectedAtmSlotItemStack = ItemStack.EMPTY;
-            helper.assertValueEqual(actualAtmSlotItemStack, expectedAtmSlotItemStack, "atmSlotItemStack");
-
-            var actualInventoryFirstSlotItemStack = fakePlayer.getInventory().getItem(0);
-            var expectedInventoryFirstSlotItemStack = new ItemStack(ModItems.BANK_CARD.get(), 64);
-            helper.assertValueEqual(actualInventoryFirstSlotItemStack, expectedInventoryFirstSlotItemStack, "inventoryFirstSlotItemStack");
-        });
+        helper.succeedIf(() -> assertQuickMoveStack(helper, fakePlayer, atmMenu,
+                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
+                ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get(), 64)
+        ));
     }
 
     @GameTest(template = BASICS_TEMPLATE)

--- a/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/ATMGameTests.java
@@ -13,7 +13,6 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
@@ -100,13 +99,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, ItemStack.EMPTY,
-                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -121,13 +120,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get()));
+        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get()));
 
         // Move the bank card from fake player's inventory to the ATM inventory using 'quickMoveStack' method
         final int bankCardSlot = GameTestUtils.findItemSlotInMenu(atmMenu, ModItems.BANK_CARD.get());
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 bankCardSlot, new ItemStack(ModItems.BANK_CARD.get(), 63),
-                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventoryFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -142,13 +141,13 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(Blocks.STONE));
+        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(Blocks.STONE));
 
         // Move the bank card from fake player's inventory to the ATM's inventory using 'quickMoveStack' method
         final int stoneSlot = GameTestUtils.findItemSlotInMenu(atmMenu, Items.STONE);
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
                 stoneSlot, new ItemStack(Blocks.STONE),
-                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY
+                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY
         ));
     }
 
@@ -164,8 +163,8 @@ public class ATMGameTests {
 
         // Move the bank card from ATM's inventory to the fake player's inventory using 'quickMoveStack' method
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
-                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
-                ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get())
+                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
+                atmMenu.getVanillaFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get())
         ));
     }
 
@@ -180,11 +179,11 @@ public class ATMGameTests {
         ATMMenu atmMenu = openATMMenu(helper, atmPos, fakePlayer);
 
         // Add bank card in fake player's inventory
-        atmMenu.getSlot(ATMMenu.VANILLA_FIRST_SLOT_INDEX).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
+        atmMenu.getSlot(atmMenu.getVanillaFirstSlotIndex()).set(new ItemStack(ModItems.BANK_CARD.get(), 63));
 
         helper.succeedIf(() -> GameTestUtils.assertQuickMoveStack(helper, fakePlayer, atmMenu,
-                ATMMenu.TE_INVENTORY_FIRST_SLOT_INDEX, ItemStack.EMPTY,
-                ATMMenu.VANILLA_FIRST_SLOT_INDEX, new ItemStack(ModItems.BANK_CARD.get(), 64)
+                atmMenu.getTileInventoryFirstSlotIndex(), ItemStack.EMPTY,
+                atmMenu.getVanillaFirstSlotIndex(), new ItemStack(ModItems.BANK_CARD.get(), 64)
         ));
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gametest/GameTestUtils.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/GameTestUtils.java
@@ -96,19 +96,22 @@ public class GameTestUtils {
         helper.assertValueEqual(actualItems.toString(), sortedExpectedItems.toString(), "playerInventoryItems");
     }
 
-    public static void assertInventoryAllMatch(GameTestHelper helper, Inventory inventory, ItemStack itemStack) {
-        inventory.items.stream().forEach(stack -> {
-            helper.assertValueEqual(stack.toString(), itemStack.toString(), "playerInventoryItem");
-        });
+    public static void assertItemStackEquals(GameTestHelper helper, ItemStack actual, ItemStack expected, String name) {
+        helper.assertValueEqual(actual.toString(), expected.toString(), name);
+    }
+
+    public static void assertInventoryAllMatch(GameTestHelper helper, Inventory inventory, ItemStack expectedItemStack) {
+        inventory.items.stream()
+                .forEach(actualItemStack -> assertItemStackEquals(helper, actualItemStack, expectedItemStack, "playerInventoryItem"));
     }
 
     public static void assertQuickMoveStack(GameTestHelper helper, Player player, AbstractContainerMenu menu, int srcIndex, ItemStack expectedSrcItemStack, int dstIndex, ItemStack expectedDstItemStack) {
         menu.quickMoveStack(player, srcIndex);
 
         var actualSrcSlotItemStack = menu.slots.get(srcIndex).getItem();
-        helper.assertValueEqual(actualSrcSlotItemStack.toString(), expectedSrcItemStack.toString(), "menuSrcSlotItemStack");
+        assertItemStackEquals(helper, actualSrcSlotItemStack, expectedSrcItemStack, "menuSrcSlotItemStack");
 
         var actualDstSlotItemStack = menu.slots.get(dstIndex).getItem();
-        helper.assertValueEqual(actualDstSlotItemStack.getItem().toString(), expectedDstItemStack.getItem().toString(), "menuDstSlotItemStack");
+        assertItemStackEquals(helper, actualDstSlotItemStack, expectedDstItemStack, "menuDstSlotItemStack");
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/gametest/GameTestUtils.java
+++ b/src/main/java/fr/valorantage/valomoney/gametest/GameTestUtils.java
@@ -6,6 +6,7 @@ import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
@@ -62,6 +63,14 @@ public class GameTestUtils {
         return -1;
     }
 
+    public static int findItemSlotInMenu(AbstractContainerMenu menu, Item item) {
+        return menu.slots.stream()
+                .filter(slot -> slot.getItem().is(item))
+                .findFirst()
+                .map(slot -> slot.index)
+                .orElse(-1);
+    }
+
     public static void assertDrops(GameTestHelper helper, AABB aabb, List<ItemStack> expectedDrops) {
         var actualDrops = helper.getLevel().getEntitiesOfClass(ItemEntity.class, aabb).stream()
                 .map(ItemEntity::getItem)
@@ -89,7 +98,17 @@ public class GameTestUtils {
 
     public static void assertInventoryAllMatch(GameTestHelper helper, Inventory inventory, ItemStack itemStack) {
         inventory.items.stream().forEach(stack -> {
-           helper.assertValueEqual(stack.toString(), itemStack.toString(), "playerInventoryItem");
+            helper.assertValueEqual(stack.toString(), itemStack.toString(), "playerInventoryItem");
         });
+    }
+
+    public static void assertQuickMoveStack(GameTestHelper helper, Player player, AbstractContainerMenu menu, int srcIndex, ItemStack expectedSrcItemStack, int dstIndex, ItemStack expectedDstItemStack) {
+        menu.quickMoveStack(player, srcIndex);
+
+        var actualSrcSlotItemStack = menu.slots.get(srcIndex).getItem();
+        helper.assertValueEqual(actualSrcSlotItemStack.toString(), expectedSrcItemStack.toString(), "menuSrcSlotItemStack");
+
+        var actualDstSlotItemStack = menu.slots.get(dstIndex).getItem();
+        helper.assertValueEqual(actualDstSlotItemStack.getItem().toString(), expectedDstItemStack.getItem().toString(), "menuDstSlotItemStack");
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -23,6 +23,22 @@ import org.slf4j.Logger;
 public class ATMMenu extends AbstractContainerMenu {
     private final static Logger LOGGER = LogUtils.getLogger();
 
+    // CREDIT GOES TO: diesieben07 | https://github.com/diesieben07/SevenCommons
+    // must assign a slot number to each of the slots used by the GUI.
+    // For this container, we can see both the tile inventory's slots as well as the player inventory slots and the hotbar.
+    // Each time we add a Slot to the container, it automatically increases the slotIndex, which means
+    //  0 - 8 = hotbar slots (which will map to the InventoryPlayer slot numbers 0 - 8)
+    //  9 - 35 = player inventory slots (which map to the InventoryPlayer slot numbers 9 - 35)
+    //  36 - 44 = TileInventory slots, which map to our TileEntity slot numbers 0 - 8)
+    private static final int HOTBAR_SLOT_COUNT = 9;
+    private static final int PLAYER_INVENTORY_ROW_COUNT = 3;
+    private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
+    private static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_COLUMN_COUNT * PLAYER_INVENTORY_ROW_COUNT;
+    private static final int VANILLA_SLOT_COUNT = HOTBAR_SLOT_COUNT + PLAYER_INVENTORY_SLOT_COUNT;
+    private static final int VANILLA_FIRST_SLOT_INDEX = 0;
+    private static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
+    private static final int TE_INVENTORY_SLOT_COUNT = 1;
+
     private final Inventory playerInventory;
     private final ATMBlockEntity blockEntity;
     private final Level level;
@@ -41,22 +57,6 @@ public class ATMMenu extends AbstractContainerMenu {
         this.addPlayerHotbar(inventory);
         this.addTileInventory();
     }
-
-    // CREDIT GOES TO: diesieben07 | https://github.com/diesieben07/SevenCommons
-    // must assign a slot number to each of the slots used by the GUI.
-    // For this container, we can see both the tile inventory's slots as well as the player inventory slots and the hotbar.
-    // Each time we add a Slot to the container, it automatically increases the slotIndex, which means
-    //  0 - 8 = hotbar slots (which will map to the InventoryPlayer slot numbers 0 - 8)
-    //  9 - 35 = player inventory slots (which map to the InventoryPlayer slot numbers 9 - 35)
-    //  36 - 44 = TileInventory slots, which map to our TileEntity slot numbers 0 - 8)
-    public static final int HOTBAR_SLOT_COUNT = 9;
-    public static final int PLAYER_INVENTORY_ROW_COUNT = 3;
-    public static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
-    public static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_COLUMN_COUNT * PLAYER_INVENTORY_ROW_COUNT;
-    public static final int VANILLA_SLOT_COUNT = HOTBAR_SLOT_COUNT + PLAYER_INVENTORY_SLOT_COUNT;
-    public static final int VANILLA_FIRST_SLOT_INDEX = 0;
-    public static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
-    public static final int TE_INVENTORY_SLOT_COUNT = 1;
 
     @Override
     public @NotNull ItemStack quickMoveStack(@NotNull Player player, int pIndex) {
@@ -95,6 +95,30 @@ public class ATMMenu extends AbstractContainerMenu {
         return stillValid(ContainerLevelAccess.create(this.level, blockEntity.getBlockPos()), player, ModBlocks.ATM.get());
     }
 
+    public int getVanillaFirstSlotIndex() {
+        return VANILLA_FIRST_SLOT_INDEX;
+    }
+
+    public int getVanillaSlotCount() {
+        return VANILLA_SLOT_COUNT;
+    }
+
+    public int getVanillaLastSlotIndex() {
+        return getVanillaFirstSlotIndex() + getVanillaSlotCount();
+    }
+
+    public int getTileInventoryFirstSlotIndex() {
+        return TE_INVENTORY_FIRST_SLOT_INDEX;
+    }
+
+    public int getTileInventorySlotCount() {
+        return TE_INVENTORY_SLOT_COUNT;
+    }
+
+    public int getTileInventoryLastSlotIndex() {
+        return getTileInventoryFirstSlotIndex() + getTileInventorySlotCount();
+    }
+
     public @NotNull Slot getSlot(int index) {
         return slots.get(index);
     }
@@ -118,11 +142,11 @@ public class ATMMenu extends AbstractContainerMenu {
     }
 
     private boolean isVanillaSlot(int index) {
-        return index >= VANILLA_FIRST_SLOT_INDEX && index < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
+        return index >= getVanillaFirstSlotIndex() && index < getVanillaLastSlotIndex();
     }
 
     private boolean isTileInventorySlot(int index) {
-        return index >= TE_INVENTORY_FIRST_SLOT_INDEX && index < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT;
+        return index >= getTileInventoryFirstSlotIndex() && index < getTileInventoryLastSlotIndex();
     }
 
     private boolean moveItemStackToVanillaInventory(ItemStack stack) {

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -4,6 +4,7 @@ import com.mojang.logging.LogUtils;
 import fr.valorantage.valomoney.attachment.ModAttachmentTypes;
 import fr.valorantage.valomoney.block.ModBlocks;
 import fr.valorantage.valomoney.block.entity.custom.ATMBlockEntity;
+import fr.valorantage.valomoney.component.ModDataComponentTypes;
 import fr.valorantage.valomoney.gui.ModMenuTypes;
 import fr.valorantage.valomoney.item.ModItems;
 import fr.valorantage.valomoney.item.custom.MonetaryItem;
@@ -22,6 +23,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -178,8 +180,21 @@ public class ATMMenu extends AbstractContainerMenu {
         return moveItemStackTo(stack, getTileInventoryFirstSlotIndex(), getTileInventoryLastSlotIndex(), false);
     }
 
-    public boolean hasBankCard() {
-        return this.getTileInventorySlot(0).getItem().is(ModItems.BANK_CARD.get());
+    public Player getBankCardBoundPlayer() {
+        var bankCard = this.getTileInventorySlot(0).getItem();
+        if (bankCard.is(ModItems.BANK_CARD.get())) {
+            var boundPlayerUUIDStr = bankCard.get(ModDataComponentTypes.PLAYER_UUID.get());
+            if (boundPlayerUUIDStr != null) {
+                var boundPlayerUUID = UUID.fromString(boundPlayerUUIDStr);
+                return this.level.getPlayerByUUID(boundPlayerUUID);
+            }
+        }
+        return null;
+    }
+
+    public boolean isPlayerBoundToBankCard() {
+        var boundPlayer = this.getBankCardBoundPlayer();
+        return boundPlayer != null && boundPlayer.getUUID().equals(this.playerInventory.player.getUUID());
     }
 
     private static <T extends MonetaryItem> List<ItemStack> distributeCash(List<T> authorizedCashItems, final float maxValue) {
@@ -236,7 +251,7 @@ public class ATMMenu extends AbstractContainerMenu {
         var player = this.playerInventory.player;
         float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
-        if (hasBankCard()) {
+        if (isPlayerBoundToBankCard()) {
             // Get cash items list to give to player
             var cashItems = distributeCash(new ArrayList<>(List.of(
                     (MonetaryItem) ModItems.BILL.get(),
@@ -260,7 +275,7 @@ public class ATMMenu extends AbstractContainerMenu {
         var player = this.playerInventory.player;
         float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
-        if (hasBankCard()) {
+        if (isPlayerBoundToBankCard()) {
             // Filter cash items of player's inventory
             final float moneyToCredit = depositCash(amount, this.playerInventory.items.stream()
                     .filter(stack -> stack.getItem() instanceof MonetaryItem)

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -36,11 +36,9 @@ public class ATMMenu extends AbstractContainerMenu {
         this.blockEntity = (ATMBlockEntity) blockEntity;
         this.level = inventory.player.level();
 
-        // FIXME: change menu item's index to TE_INVENTORY_FIRST_SLOT_INDEX (must be declared before)
-        this.addSlot(new SlotItemHandler(this.blockEntity.inventory, 0, 29, 24));
-
         this.addPlayerInventory(inventory);
         this.addPlayerHotbar(inventory);
+        this.addTileInventory();
     }
 
     // CREDIT GOES TO: diesieben07 | https://github.com/diesieben07/SevenCommons
@@ -57,12 +55,10 @@ public class ATMMenu extends AbstractContainerMenu {
     private static final int VANILLA_SLOT_COUNT = HOTBAR_SLOT_COUNT + PLAYER_INVENTORY_SLOT_COUNT;
     private static final int VANILLA_FIRST_SLOT_INDEX = 0;
     private static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
-
     private static final int TE_INVENTORY_SLOT_COUNT = 1;
 
     @Override
     public ItemStack quickMoveStack(Player player, int pIndex) {
-        // FIXME: item stack is always moved first in the last slot of the player's hotbar
         Slot sourceSlot = slots.get(pIndex);
         if (!sourceSlot.hasItem()) {
             return ItemStack.EMPTY;
@@ -101,10 +97,14 @@ public class ATMMenu extends AbstractContainerMenu {
         return stillValid(ContainerLevelAccess.create(this.level, blockEntity.getBlockPos()), player, ModBlocks.ATM.get());
     }
 
+    private void addTileInventory() {
+        this.addSlot(new SlotItemHandler(this.blockEntity.inventory, 0, 29, 24));
+    }
+
     private void addPlayerInventory(Inventory playerInventory) {
         for (int i = 0; i < 3; ++i) {
             for (int l = 0; l < 9; ++l) {
-                this.addSlot(new Slot(playerInventory, l + i * 9 + 9, 15 + l * 18, 86 + i * 18));
+                this.addSlot(new Slot(playerInventory, VANILLA_FIRST_SLOT_INDEX + l + i * 9 + 9, 15 + l * 18, 86 + i * 18));
             }
         }
     }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.items.SlotItemHandler;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 public class ATMMenu extends AbstractContainerMenu {
@@ -58,7 +59,7 @@ public class ATMMenu extends AbstractContainerMenu {
     public static final int TE_INVENTORY_SLOT_COUNT = 1;
 
     @Override
-    public ItemStack quickMoveStack(Player player, int pIndex) {
+    public @NotNull ItemStack quickMoveStack(@NotNull Player player, int pIndex) {
         Slot sourceSlot = slots.get(pIndex);
         if (!sourceSlot.hasItem()) {
             return ItemStack.EMPTY;
@@ -90,11 +91,11 @@ public class ATMMenu extends AbstractContainerMenu {
     }
 
     @Override
-    public boolean stillValid(Player player) {
+    public boolean stillValid(@NotNull Player player) {
         return stillValid(ContainerLevelAccess.create(this.level, blockEntity.getBlockPos()), player, ModBlocks.ATM.get());
     }
 
-    public Slot getSlot(int index) {
+    public @NotNull Slot getSlot(int index) {
         return slots.get(index);
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -67,21 +67,18 @@ public class ATMMenu extends AbstractContainerMenu {
         ItemStack sourceStack = sourceSlot.getItem();
         ItemStack copyOfSourceStack = sourceStack.copy();
 
-        // Check if the slot clicked is one of the vanilla container slots
         if (isVanillaSlot(pIndex)) {
-            // This is a vanilla container slot so merge the stack into the tile inventory
-            if (!moveItemStackTo(sourceStack, TE_INVENTORY_FIRST_SLOT_INDEX, TE_INVENTORY_FIRST_SLOT_INDEX
-                    + TE_INVENTORY_SLOT_COUNT, false)) {
+            if (!moveItemStackToTileInventory(sourceStack)) {
                 return ItemStack.EMPTY;
             }
         } else if (isTileInventorySlot(pIndex)) {
-            // This is a TE slot so merge the stack into the players inventory
-            if (!moveItemStackTo(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+            if (!moveItemStackToVanillaInventory(sourceStack)) {
                 return ItemStack.EMPTY;
             }
         } else {
             return ItemStack.EMPTY;
         }
+
         // If stack size == 0 (the entire stack was moved) set slot contents to null
         if (sourceStack.getCount() == 0) {
             sourceSlot.set(ItemStack.EMPTY);
@@ -125,6 +122,14 @@ public class ATMMenu extends AbstractContainerMenu {
 
     private boolean isTileInventorySlot(int index) {
         return index >= TE_INVENTORY_FIRST_SLOT_INDEX && index < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT;
+    }
+
+    private boolean moveItemStackToVanillaInventory(ItemStack stack) {
+        return moveItemStackTo(stack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false);
+    }
+
+    private boolean moveItemStackToTileInventory(ItemStack stack) {
+        return moveItemStackTo(stack, TE_INVENTORY_FIRST_SLOT_INDEX, TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT, false);
     }
 
     // FIXME: must check if there is enough space in inventory

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -230,7 +230,6 @@ public class ATMMenu extends AbstractContainerMenu {
     public void credit(float amount) {
         var player = this.playerInventory.player;
         var actualPlayerMoney = player.getData(ModAttachmentTypes.MONEY);
-        LOGGER.debug("{}'s actual balance is {}$", player.getDisplayName().getString(), actualPlayerMoney);
 
         if (hasBankCard()) {
             float playerInventoryMoney = 0;
@@ -254,12 +253,8 @@ public class ATMMenu extends AbstractContainerMenu {
                 }
             }
 
-            LOGGER.debug("Credit {}$ to {}'s account", playerInventoryMoney, player.getName().getString());
 
             player.setData(ModAttachmentTypes.MONEY, actualPlayerMoney + playerInventoryMoney);
-            LOGGER.debug("{}'s new balance is {}$", player.getDisplayName().getString(), player.getData(ModAttachmentTypes.MONEY));
-        } else {
-            LOGGER.debug("Cannot credit without a bank card");
         }
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -68,13 +68,13 @@ public class ATMMenu extends AbstractContainerMenu {
         ItemStack copyOfSourceStack = sourceStack.copy();
 
         // Check if the slot clicked is one of the vanilla container slots
-        if (pIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
+        if (isVanillaSlot(pIndex)) {
             // This is a vanilla container slot so merge the stack into the tile inventory
             if (!moveItemStackTo(sourceStack, TE_INVENTORY_FIRST_SLOT_INDEX, TE_INVENTORY_FIRST_SLOT_INDEX
                     + TE_INVENTORY_SLOT_COUNT, false)) {
                 return ItemStack.EMPTY;
             }
-        } else if (pIndex < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT) {
+        } else if (isTileInventorySlot(pIndex)) {
             // This is a TE slot so merge the stack into the players inventory
             if (!moveItemStackTo(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
                 return ItemStack.EMPTY;
@@ -117,6 +117,14 @@ public class ATMMenu extends AbstractContainerMenu {
         for (int i = 0; i < 9; ++i) {
             this.addSlot(new Slot(playerInventory, i, 15 + i * 18, 144));
         }
+    }
+
+    private boolean isVanillaSlot(int index) {
+        return index >= VANILLA_FIRST_SLOT_INDEX && index < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
+    }
+
+    private boolean isTileInventorySlot(int index) {
+        return index >= TE_INVENTORY_FIRST_SLOT_INDEX && index < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT;
     }
 
     // FIXME: must check if there is enough space in inventory

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -48,14 +48,14 @@ public class ATMMenu extends AbstractContainerMenu {
     //  0 - 8 = hotbar slots (which will map to the InventoryPlayer slot numbers 0 - 8)
     //  9 - 35 = player inventory slots (which map to the InventoryPlayer slot numbers 9 - 35)
     //  36 - 44 = TileInventory slots, which map to our TileEntity slot numbers 0 - 8)
-    private static final int HOTBAR_SLOT_COUNT = 9;
-    private static final int PLAYER_INVENTORY_ROW_COUNT = 3;
-    private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
-    private static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_COLUMN_COUNT * PLAYER_INVENTORY_ROW_COUNT;
-    private static final int VANILLA_SLOT_COUNT = HOTBAR_SLOT_COUNT + PLAYER_INVENTORY_SLOT_COUNT;
-    private static final int VANILLA_FIRST_SLOT_INDEX = 0;
-    private static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
-    private static final int TE_INVENTORY_SLOT_COUNT = 1;
+    public static final int HOTBAR_SLOT_COUNT = 9;
+    public static final int PLAYER_INVENTORY_ROW_COUNT = 3;
+    public static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
+    public static final int PLAYER_INVENTORY_SLOT_COUNT = PLAYER_INVENTORY_COLUMN_COUNT * PLAYER_INVENTORY_ROW_COUNT;
+    public static final int VANILLA_SLOT_COUNT = HOTBAR_SLOT_COUNT + PLAYER_INVENTORY_SLOT_COUNT;
+    public static final int VANILLA_FIRST_SLOT_INDEX = 0;
+    public static final int TE_INVENTORY_FIRST_SLOT_INDEX = VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT;
+    public static final int TE_INVENTORY_SLOT_COUNT = 1;
 
     @Override
     public ItemStack quickMoveStack(Player player, int pIndex) {

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -97,6 +97,10 @@ public class ATMMenu extends AbstractContainerMenu {
         return stillValid(ContainerLevelAccess.create(this.level, blockEntity.getBlockPos()), player, ModBlocks.ATM.get());
     }
 
+    public Slot getSlot(int index) {
+        return slots.get(index);
+    }
+
     private void addTileInventory() {
         this.addSlot(new SlotItemHandler(this.blockEntity.inventory, 0, 29, 24));
     }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -29,7 +29,7 @@ public class ATMMenu extends AbstractContainerMenu {
     // Each time we add a Slot to the container, it automatically increases the slotIndex, which means
     //  0 - 8 = hotbar slots (which will map to the InventoryPlayer slot numbers 0 - 8)
     //  9 - 35 = player inventory slots (which map to the InventoryPlayer slot numbers 9 - 35)
-    //  36 - 44 = TileInventory slots, which map to our TileEntity slot numbers 0 - 8)
+    //  36 - 36 = TileInventory slots, which map to our TileEntity slot numbers 0 - 0)
     private static final int HOTBAR_SLOT_COUNT = 9;
     private static final int PLAYER_INVENTORY_ROW_COUNT = 3;
     private static final int PLAYER_INVENTORY_COLUMN_COUNT = 9;
@@ -68,7 +68,7 @@ public class ATMMenu extends AbstractContainerMenu {
         ItemStack sourceStack = sourceSlot.getItem();
         ItemStack copyOfSourceStack = sourceStack.copy();
 
-        if (isVanillaSlot(pIndex)) {
+        if (isVanillaInventorySlot(pIndex)) {
             if (!moveItemStackToTileInventory(sourceStack)) {
                 return ItemStack.EMPTY;
             }
@@ -95,16 +95,16 @@ public class ATMMenu extends AbstractContainerMenu {
         return stillValid(ContainerLevelAccess.create(this.level, blockEntity.getBlockPos()), player, ModBlocks.ATM.get());
     }
 
-    public int getVanillaFirstSlotIndex() {
+    public int getVanillaInventoryFirstSlotIndex() {
         return VANILLA_FIRST_SLOT_INDEX;
     }
 
-    public int getVanillaSlotCount() {
+    public int getVanillaInventorySlotCount() {
         return VANILLA_SLOT_COUNT;
     }
 
-    public int getVanillaLastSlotIndex() {
-        return getVanillaFirstSlotIndex() + getVanillaSlotCount();
+    public int getVanillaInventoryLastSlotIndex() {
+        return getVanillaInventoryFirstSlotIndex() + getVanillaInventorySlotCount();
     }
 
     public int getTileInventoryFirstSlotIndex() {
@@ -130,7 +130,7 @@ public class ATMMenu extends AbstractContainerMenu {
     private void addPlayerInventory(Inventory playerInventory) {
         for (int i = 0; i < 3; ++i) {
             for (int l = 0; l < 9; ++l) {
-                this.addSlot(new Slot(playerInventory, VANILLA_FIRST_SLOT_INDEX + l + i * 9 + 9, 15 + l * 18, 86 + i * 18));
+                this.addSlot(new Slot(playerInventory, getVanillaInventoryFirstSlotIndex() + l + i * 9 + 9, 15 + l * 18, 86 + i * 18));
             }
         }
     }
@@ -141,8 +141,8 @@ public class ATMMenu extends AbstractContainerMenu {
         }
     }
 
-    private boolean isVanillaSlot(int index) {
-        return index >= getVanillaFirstSlotIndex() && index < getVanillaLastSlotIndex();
+    private boolean isVanillaInventorySlot(int index) {
+        return index >= getVanillaInventoryFirstSlotIndex() && index < getVanillaInventoryLastSlotIndex();
     }
 
     private boolean isTileInventorySlot(int index) {
@@ -150,11 +150,11 @@ public class ATMMenu extends AbstractContainerMenu {
     }
 
     private boolean moveItemStackToVanillaInventory(ItemStack stack) {
-        return moveItemStackTo(stack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false);
+        return moveItemStackTo(stack, getVanillaInventoryFirstSlotIndex(), getVanillaInventoryLastSlotIndex(), false);
     }
 
     private boolean moveItemStackToTileInventory(ItemStack stack) {
-        return moveItemStackTo(stack, TE_INVENTORY_FIRST_SLOT_INDEX, TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT, false);
+        return moveItemStackTo(stack, getTileInventoryFirstSlotIndex(), getTileInventoryLastSlotIndex(), false);
     }
 
     // FIXME: must check if there is enough space in inventory

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -20,6 +20,9 @@ import net.neoforged.neoforge.items.SlotItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ATMMenu extends AbstractContainerMenu {
     private final static Logger LOGGER = LogUtils.getLogger();
 
@@ -177,51 +180,50 @@ public class ATMMenu extends AbstractContainerMenu {
         return this.getTileInventorySlot(0).getItem().is(ModItems.BANK_CARD.get());
     }
 
-    // FIXME: must check if there is enough space in inventory
+    private static <T extends MonetaryItem> List<ItemStack> withdrawCash(List<T> authorizedCashItems, final float maxValue) {
+        authorizedCashItems.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
+
+        List<ItemStack> cashItems = new ArrayList<>();
+        float currentValue = maxValue;
+        for (var cashItem : authorizedCashItems) {
+            final int count = (int) (currentValue / cashItem.getValue());
+            final int fullStackCount = count / 64;
+            final int remaining = count % 64;
+
+            for (int i = 0; i < fullStackCount; ++i) {
+                cashItems.add(new ItemStack(cashItem, 64));
+            }
+
+            if (remaining > 0) {
+                cashItems.add(new ItemStack(cashItem, remaining));
+            }
+
+            currentValue -= fullStackCount * 64 * cashItem.getValue() + remaining * cashItem.getValue();
+        }
+        return cashItems;
+    }
+
     public void debit(float amount) {
         var player = this.playerInventory.player;
-        var currentPlayerMoney = player.getData(ModAttachmentTypes.MONEY);
-        LOGGER.debug("{}'s actual balance is {}$", player.getDisplayName().getString(), currentPlayerMoney);
+        float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
         if (hasBankCard()) {
-            var billItemStack = new ItemStack(ModItems.BILL.get(), 1);
-            var billItem = (MonetaryItem) billItemStack.getItem();
-            int billCount = (int) (amount / billItem.getValue());
-            billItemStack.setCount(billCount);
-            float billMoney = billCount * billItem.getValue();
-            amount -= billMoney;
+            // Get cash items list to give to player
+            var cashItems = withdrawCash(new ArrayList<>(List.of(
+                    (MonetaryItem) ModItems.BILL.get(),
+                    (MonetaryItem) ModItems.COIN.get()
+            )), Math.min(amount, currentPlayerBalance));
 
-            var coinItemStack = new ItemStack(ModItems.COIN.get(), 1);
-            var coinItem = (MonetaryItem) coinItemStack.getItem();
-            int coinCount = (int) (amount / coinItem.getValue());
-            coinItemStack.setCount(coinCount);
-            float coinMoney = coinCount * coinItem.getValue();
-            amount -= coinMoney;
-
-            float actualDebit = billMoney + coinMoney;
-            if (currentPlayerMoney < actualDebit) {
-                LOGGER.debug("{}'s has insufficient funds", player.getDisplayName().getString());
-                return;
+            // Distribute cash items in player's inventory and updating dynamically player's balance
+            for (var cashItemStack : cashItems) {
+                if (this.playerInventory.add(cashItemStack.copy())) {
+                    // Withdraw cashItemStack's value from player's balance
+                    var item = cashItemStack.getItem();
+                    var monetaryItem = (MonetaryItem) item;
+                    currentPlayerBalance -= monetaryItem.getValue() * cashItemStack.getCount();
+                    player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance);
+                }
             }
-
-            if (!this.playerInventory.add(billItemStack)) {
-                LOGGER.error("Couldn't add bills item to player's inventory: {}", billItemStack);
-                return;
-            }
-
-            if (!this.playerInventory.add(coinItemStack)) {
-                LOGGER.error("Couldn't add coins item to player's inventory: {}", coinItemStack);
-                return;
-            }
-
-            LOGGER.debug("Debit will give: {} bills (5$), {} coins (1$)", billCount, coinCount);
-            LOGGER.debug(String.format("Money that will not be given: %.2f$", amount));
-
-            player.setData(ModAttachmentTypes.MONEY, currentPlayerMoney - actualDebit);
-            LOGGER.debug("{}'s new balance is {}$", player.getDisplayName().getString(), player.getData(ModAttachmentTypes.MONEY));
-
-        } else {
-            LOGGER.debug("Cannot debit without a bank card");
         }
     }
 

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -9,6 +9,7 @@ import fr.valorantage.valomoney.gui.ModMenuTypes;
 import fr.valorantage.valomoney.item.ModItems;
 import fr.valorantage.valomoney.item.custom.CashItem;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -243,7 +244,7 @@ public class ATMMenu extends AbstractContainerMenu {
         var player = this.playerInventory.player;
 
         if (this.isPlayerBoundToBankCard(player)) {
-            float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
+            final float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
             // Get cash items list to give to player
             var cashItems = distributeCash(new ArrayList<>(List.of(
@@ -252,15 +253,19 @@ public class ATMMenu extends AbstractContainerMenu {
             )), Math.min(amount, currentPlayerBalance));
 
             // Distribute cash items in player's inventory and updating dynamically player's balance
+            float moneyToDebit = 0.f;
             for (var cashItemStack : cashItems) {
                 if (this.playerInventory.add(cashItemStack.copy())) {
                     // Withdraw cashItemStack's value from player's balance
                     var item = cashItemStack.getItem();
-                    var monetaryItem = (CashItem) item;
-                    currentPlayerBalance -= monetaryItem.getValue() * cashItemStack.getCount();
-                    player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance);
+                    var cashItem = (CashItem) item;
+                    final float cashItemValue = cashItem.getValue() * cashItemStack.getCount();
+                    moneyToDebit += cashItemValue;
                 }
             }
+
+            player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance - moneyToDebit);
+            player.sendSystemMessage(Component.literal(String.format("You have been debited of: %.2f$", moneyToDebit)));
         }
     }
 
@@ -276,6 +281,7 @@ public class ATMMenu extends AbstractContainerMenu {
             );
 
             player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance + moneyToCredit);
+            player.sendSystemMessage(Component.literal(String.format("You have been credited of: %.2f$", moneyToCredit)));
         }
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -180,21 +180,13 @@ public class ATMMenu extends AbstractContainerMenu {
         return moveItemStackTo(stack, getTileInventoryFirstSlotIndex(), getTileInventoryLastSlotIndex(), false);
     }
 
-    public Player getBankCardBoundPlayer() {
-        var bankCard = this.getTileInventorySlot(0).getItem();
-        if (bankCard.is(ModItems.BANK_CARD.get())) {
-            var boundPlayerUUIDStr = bankCard.get(ModDataComponentTypes.PLAYER_UUID.get());
-            if (boundPlayerUUIDStr != null) {
-                var boundPlayerUUID = UUID.fromString(boundPlayerUUIDStr);
-                return this.level.getPlayerByUUID(boundPlayerUUID);
-            }
+    public boolean isPlayerBoundToBankCard(Player player) {
+        var bankCardSlotItem = this.getTileInventorySlot(0).getItem();
+        if (bankCardSlotItem.is(ModItems.BANK_CARD.get())) {
+            String boundPlayerUUIDStr = bankCardSlotItem.get(ModDataComponentTypes.PLAYER_UUID);
+            return boundPlayerUUIDStr != null && player.getUUID().equals(UUID.fromString(boundPlayerUUIDStr));
         }
-        return null;
-    }
-
-    public boolean isPlayerBoundToBankCard() {
-        var boundPlayer = this.getBankCardBoundPlayer();
-        return boundPlayer != null && boundPlayer.getUUID().equals(this.playerInventory.player.getUUID());
+        return false;
     }
 
     private static <T extends MonetaryItem> List<ItemStack> distributeCash(List<T> authorizedCashItems, final float maxValue) {
@@ -249,9 +241,10 @@ public class ATMMenu extends AbstractContainerMenu {
 
     public void debit(float amount) {
         var player = this.playerInventory.player;
-        float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
-        if (isPlayerBoundToBankCard()) {
+        if (this.isPlayerBoundToBankCard(player)) {
+            float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
+
             // Get cash items list to give to player
             var cashItems = distributeCash(new ArrayList<>(List.of(
                     (MonetaryItem) ModItems.BILL.get(),
@@ -273,9 +266,10 @@ public class ATMMenu extends AbstractContainerMenu {
 
     public void credit(float amount) {
         var player = this.playerInventory.player;
-        float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
-        if (isPlayerBoundToBankCard()) {
+        if (this.isPlayerBoundToBankCard(player)) {
+            float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
+
             // Filter cash items of player's inventory
             final float moneyToCredit = depositCash(amount, this.playerInventory.items.stream()
                     .filter(stack -> stack.getItem() instanceof MonetaryItem)

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -7,7 +7,7 @@ import fr.valorantage.valomoney.block.entity.custom.ATMBlockEntity;
 import fr.valorantage.valomoney.component.ModDataComponentTypes;
 import fr.valorantage.valomoney.gui.ModMenuTypes;
 import fr.valorantage.valomoney.item.ModItems;
-import fr.valorantage.valomoney.item.custom.MonetaryItem;
+import fr.valorantage.valomoney.item.custom.CashItem;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -189,7 +189,7 @@ public class ATMMenu extends AbstractContainerMenu {
         return false;
     }
 
-    private static <T extends MonetaryItem> List<ItemStack> distributeCash(List<T> authorizedCashItems, final float maxValue) {
+    private static <T extends CashItem> List<ItemStack> distributeCash(List<T> authorizedCashItems, final float maxValue) {
         authorizedCashItems.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
 
         List<ItemStack> cashItems = new ArrayList<>();
@@ -221,7 +221,7 @@ public class ATMMenu extends AbstractContainerMenu {
                 return;
             }
 
-            var monetaryItem = (MonetaryItem) stack.getItem();
+            var monetaryItem = (CashItem) stack.getItem();
             float valuePerUnit = monetaryItem.getValue();
             int count = stack.getCount();
 
@@ -247,8 +247,8 @@ public class ATMMenu extends AbstractContainerMenu {
 
             // Get cash items list to give to player
             var cashItems = distributeCash(new ArrayList<>(List.of(
-                    (MonetaryItem) ModItems.BILL.get(),
-                    (MonetaryItem) ModItems.COIN.get()
+                    (CashItem) ModItems.BILL.get(),
+                    (CashItem) ModItems.COIN.get()
             )), Math.min(amount, currentPlayerBalance));
 
             // Distribute cash items in player's inventory and updating dynamically player's balance
@@ -256,7 +256,7 @@ public class ATMMenu extends AbstractContainerMenu {
                 if (this.playerInventory.add(cashItemStack.copy())) {
                     // Withdraw cashItemStack's value from player's balance
                     var item = cashItemStack.getItem();
-                    var monetaryItem = (MonetaryItem) item;
+                    var monetaryItem = (CashItem) item;
                     currentPlayerBalance -= monetaryItem.getValue() * cashItemStack.getCount();
                     player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance);
                 }
@@ -272,7 +272,7 @@ public class ATMMenu extends AbstractContainerMenu {
 
             // Filter cash items of player's inventory
             final float moneyToCredit = depositCash(amount, this.playerInventory.items.stream()
-                    .filter(stack -> stack.getItem() instanceof MonetaryItem)
+                    .filter(stack -> stack.getItem() instanceof CashItem)
             );
 
             player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance + moneyToCredit);

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -157,13 +157,17 @@ public class ATMMenu extends AbstractContainerMenu {
         return moveItemStackTo(stack, getTileInventoryFirstSlotIndex(), getTileInventoryLastSlotIndex(), false);
     }
 
+    public boolean hasBankCard() {
+        return this.getSlot(this.getTileInventoryFirstSlotIndex()).getItem().is(ModItems.BANK_CARD.get());
+    }
+
     // FIXME: must check if there is enough space in inventory
     public void debit(float amount) {
         var player = this.playerInventory.player;
         var currentPlayerMoney = player.getData(ModAttachmentTypes.MONEY);
         LOGGER.debug("{}'s actual balance is {}$", player.getDisplayName().getString(), currentPlayerMoney);
 
-        if (this.blockEntity.inventory.getStackInSlot(0).getItem() == ModItems.BANK_CARD.get()) {
+        if (hasBankCard()) {
             var billItemStack = new ItemStack(ModItems.BILL.get(), 1);
             var billItem = (MonetaryItem) billItemStack.getItem();
             int billCount = (int) (amount / billItem.getValue());
@@ -210,7 +214,7 @@ public class ATMMenu extends AbstractContainerMenu {
         var actualPlayerMoney = player.getData(ModAttachmentTypes.MONEY);
         LOGGER.debug("{}'s actual balance is {}$", player.getDisplayName().getString(), actualPlayerMoney);
 
-        if (this.blockEntity.inventory.getStackInSlot(0).getItem() == ModItems.BANK_CARD.get()) {
+        if (hasBankCard()) {
             float playerInventoryMoney = 0;
             for (int i = 0; i < this.playerInventory.getContainerSize(); i++) {
                 var item = this.playerInventory.getItem(i);

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -145,8 +145,24 @@ public class ATMMenu extends AbstractContainerMenu {
         return index >= getVanillaInventoryFirstSlotIndex() && index < getVanillaInventoryLastSlotIndex();
     }
 
+    public Slot getVanillaInventorySlot(int index) throws IndexOutOfBoundsException {
+        final int correctedIndex = getVanillaInventoryFirstSlotIndex() + index;
+        if (!isVanillaInventorySlot(correctedIndex)) {
+            throw new IndexOutOfBoundsException(index);
+        }
+        return this.getSlot(correctedIndex);
+    }
+
     private boolean isTileInventorySlot(int index) {
         return index >= getTileInventoryFirstSlotIndex() && index < getTileInventoryLastSlotIndex();
+    }
+
+    public Slot getTileInventorySlot(int index) throws IndexOutOfBoundsException {
+        final int correctedIndex = this.getTileInventoryFirstSlotIndex() + index;
+        if (!isTileInventorySlot(correctedIndex)) {
+            throw new IndexOutOfBoundsException(index);
+        }
+        return this.getSlot(correctedIndex);
     }
 
     private boolean moveItemStackToVanillaInventory(ItemStack stack) {
@@ -158,7 +174,7 @@ public class ATMMenu extends AbstractContainerMenu {
     }
 
     public boolean hasBankCard() {
-        return this.getSlot(this.getTileInventoryFirstSlotIndex()).getItem().is(ModItems.BANK_CARD.get());
+        return this.getTileInventorySlot(0).getItem().is(ModItems.BANK_CARD.get());
     }
 
     // FIXME: must check if there is enough space in inventory

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ATMMenu extends AbstractContainerMenu {
     private final static Logger LOGGER = LogUtils.getLogger();
@@ -203,6 +205,13 @@ public class ATMMenu extends AbstractContainerMenu {
         return cashItems;
     }
 
+    private static float depositCash(final float maxValue, Stream<ItemStack> cashItems) {
+        return Math.min(maxValue, cashItems
+                .map(stack -> ((MonetaryItem) stack.getItem()).getValue() * stack.getCount())
+                .reduce(0f, Float::sum)
+        );
+    }
+
     public void debit(float amount) {
         var player = this.playerInventory.player;
         float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
@@ -229,32 +238,15 @@ public class ATMMenu extends AbstractContainerMenu {
 
     public void credit(float amount) {
         var player = this.playerInventory.player;
-        var actualPlayerMoney = player.getData(ModAttachmentTypes.MONEY);
+        float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
         if (hasBankCard()) {
-            float playerInventoryMoney = 0;
-            for (int i = 0; i < this.playerInventory.getContainerSize(); i++) {
-                var item = this.playerInventory.getItem(i);
-                if (item.getItem() instanceof MonetaryItem monetaryItem) {
-                    float itemStackAmount = monetaryItem.getValue() * item.getCount();
+            // Filter cash items of player's inventory
+            final float moneyToCredit = depositCash(amount, this.playerInventory.items.stream()
+                    .filter(stack -> stack.getItem() instanceof MonetaryItem)
+            );
 
-                    if (playerInventoryMoney + itemStackAmount > amount) {
-                        float remainingAmount = amount - playerInventoryMoney;
-                        int maxItemCount = (int) (remainingAmount / monetaryItem.getValue());
-                        if (maxItemCount > 0) {
-                            playerInventoryMoney += monetaryItem.getValue() * maxItemCount;
-                            item.setCount(item.getCount() - maxItemCount);
-                        }
-                        break;
-                    } else {
-                        playerInventoryMoney += itemStackAmount;
-                        this.playerInventory.removeItem(i, item.getCount());
-                    }
-                }
-            }
-
-
-            player.setData(ModAttachmentTypes.MONEY, actualPlayerMoney + playerInventoryMoney);
+            player.setData(ModAttachmentTypes.MONEY.get(), currentPlayerBalance + moneyToCredit);
         }
     }
 }

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -182,7 +182,7 @@ public class ATMMenu extends AbstractContainerMenu {
         return this.getTileInventorySlot(0).getItem().is(ModItems.BANK_CARD.get());
     }
 
-    private static <T extends MonetaryItem> List<ItemStack> withdrawCash(List<T> authorizedCashItems, final float maxValue) {
+    private static <T extends MonetaryItem> List<ItemStack> distributeCash(List<T> authorizedCashItems, final float maxValue) {
         authorizedCashItems.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
 
         List<ItemStack> cashItems = new ArrayList<>();
@@ -232,14 +232,13 @@ public class ATMMenu extends AbstractContainerMenu {
         return total.get();
     }
 
-
     public void debit(float amount) {
         var player = this.playerInventory.player;
         float currentPlayerBalance = player.getData(ModAttachmentTypes.MONEY);
 
         if (hasBankCard()) {
             // Get cash items list to give to player
-            var cashItems = withdrawCash(new ArrayList<>(List.of(
+            var cashItems = distributeCash(new ArrayList<>(List.of(
                     (MonetaryItem) ModItems.BILL.get(),
                     (MonetaryItem) ModItems.COIN.get()
             )), Math.min(amount, currentPlayerBalance));

--- a/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
+++ b/src/main/java/fr/valorantage/valomoney/gui/custom/ATMMenu.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 public class ATMMenu extends AbstractContainerMenu {
@@ -206,11 +206,32 @@ public class ATMMenu extends AbstractContainerMenu {
     }
 
     private static float depositCash(final float maxValue, Stream<ItemStack> cashItems) {
-        return Math.min(maxValue, cashItems
-                .map(stack -> ((MonetaryItem) stack.getItem()).getValue() * stack.getCount())
-                .reduce(0f, Float::sum)
-        );
+        AtomicReference<Float> total = new AtomicReference<>(0.f);
+        AtomicReference<Float> remaining = new AtomicReference<>(maxValue);
+
+        cashItems.forEach(stack -> {
+            if (remaining.get() <= 0.f) {
+                return;
+            }
+
+            var monetaryItem = (MonetaryItem) stack.getItem();
+            float valuePerUnit = monetaryItem.getValue();
+            int count = stack.getCount();
+
+            int canTake = Math.min(count, (int) (remaining.get() / valuePerUnit));
+
+            if (canTake > 0) {
+                float added = canTake * valuePerUnit;
+                total.updateAndGet(v -> v + added);
+                remaining.updateAndGet(v -> v - added);
+
+                stack.shrink(canTake);
+            }
+        });
+
+        return total.get();
     }
+
 
     public void debit(float amount) {
         var player = this.playerInventory.player;

--- a/src/main/java/fr/valorantage/valomoney/item/ModItems.java
+++ b/src/main/java/fr/valorantage/valomoney/item/ModItems.java
@@ -3,7 +3,7 @@ package fr.valorantage.valomoney.item;
 import fr.valorantage.valomoney.ValomoneyMod;
 import fr.valorantage.valomoney.block.ModBlocks;
 import fr.valorantage.valomoney.item.custom.BankCardItem;
-import fr.valorantage.valomoney.item.custom.MonetaryItem;
+import fr.valorantage.valomoney.item.custom.CashItem;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.neoforged.bus.api.IEventBus;
@@ -15,8 +15,8 @@ public class ModItems {
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(ValomoneyMod.MODID);
 
     // Creates monetary items
-    public static final DeferredItem<Item> COIN = ITEMS.register("coin", () -> new MonetaryItem(1.0f));
-    public static final DeferredItem<Item> BILL = ITEMS.register("bill", () -> new MonetaryItem(5.0f));
+    public static final DeferredItem<Item> COIN = ITEMS.register("coin", () -> new CashItem(1.0f));
+    public static final DeferredItem<Item> BILL = ITEMS.register("bill", () -> new CashItem(5.0f));
 
     // Creates ATM block item
     public static final DeferredItem<BlockItem> ATM_ITEM = ITEMS.register("atm", () -> new BlockItem(ModBlocks.ATM.get(), new Item.Properties()));

--- a/src/main/java/fr/valorantage/valomoney/item/custom/CashItem.java
+++ b/src/main/java/fr/valorantage/valomoney/item/custom/CashItem.java
@@ -7,10 +7,10 @@ import net.minecraft.world.item.TooltipFlag;
 
 import java.util.List;
 
-public class MonetaryItem extends Item {
+public class CashItem extends Item {
     private final float value;
 
-    public MonetaryItem(float value) {
+    public CashItem(float value) {
         super(new Item.Properties());
 
         if (value <= 0.0f)


### PR DESCRIPTION
This pull request addresses and resolves all major functional and user experience issues previously identified in the ATM block and its associated menu.

---

### 🔧 Key Fixes and Refactorings

#### 1. 🎯 Reliable Slot Indexing in `ATMMenu`

* Introduced helper methods `getVanillaInventoryFirstSlotIndex()` and `getTileInventoryFirstSlotIndex()` to clarify and encapsulate slot index boundaries.
* This eliminates the inconsistent behavior with `quickMoveStack` (shift-click), which now correctly transfers items between the ATM and player inventories.

#### 2. 💰 Complete Refactor of `credit()` and `debit()` Methods

* These methods have been **fully rewritten** to ensure correctness, clarity, and proper money/item synchronization.
* The previous bug where money wasn't debited when items were already given is now fixed.
* Items are now **only granted after successful deduction or crediting** of the player's balance.

#### 3. 💳 Bank Card Binding Enforcement

* Players **must now bind their bank card** to themselves before using it in the ATM (via right-click).
* Credit and debit operations are only authorized if the inserted card is properly bound to the interacting player.
* This change improves account security and prevents misuse.

#### 4. 🧠 `useWithoutItem()` Removed

* After investigation, it was confirmed that `useItemOn()` is called even when the player is holding nothing.
* Thus, overriding `useWithoutItem()` is **unnecessary** and the corresponding test has been removed to avoid confusion.

#### 5. 💬 Player Feedback via Chat

* Players now receive **chat messages** confirming successful credit or debit operations.

---

### 📝 Additional Notes

* Stack limits for the bank card slot were **not enforced**, since inserting multiple cards (even stacked) has no adverse effect.

  * **Stacking is now implicitly controlled**: only unbound cards or cards bound to the same UUID (same NBT data) are stackable.
  * This behavior is consistent with the current item logic and prevents confusion without additional constraints.